### PR TITLE
chore: bump up argocd to v2.6.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN git clone --branch=20200403-1 --depth=1 https://github.com/camptocamp/helm-s
 RUN wget -O /tmp/helmfile https://github.com/roboll/helmfile/releases/download/v0.144.0/helmfile_linux_amd64 && chmod +x /tmp/helmfile
 RUN wget -O /tmp/yq https://github.com/mikefarah/yq/releases/download/v4.25.1/yq_linux_amd64 && chmod +x /tmp/yq
 
-FROM quay.io/argoproj/argocd:v2.8.2
+FROM quay.io/argoproj/argocd:v2.6.15
 USER root
 COPY argocd-repo-server-wrapper /usr/local/bin/
 COPY argocd-helmfile /usr/local/bin/

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To use this custom sops supported image when deploying ArgoCD using the [Helm ch
 global:
   image:
     repository: "thenaim/argocd"
-    tag: "v2.8.2"
+    tag: "v2.6.15"
 ```
 
 ### Sops with an AWS KMS key


### PR DESCRIPTION
Release information: https://github.com/argoproj/argo-cd/releases/tag/v2.6.15