### PR TITLE
chore: bump up argocd to v2.13.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ RUN git clone --branch=20240712-1 --depth=1 https://github.com/camptocamp/helm-s
     cd helm-sops && \
     go build
 
-FROM quay.io/argoproj/argocd:v2.12.0
+FROM quay.io/argoproj/argocd:v2.13.0
 USER root
 COPY argocd-repo-server-wrapper /usr/local/bin/
 COPY --from=builder /go/helm-sops/helm-sops /usr/local/bin/

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To use this custom sops supported image when deploying ArgoCD using the [Helm ch
 global:
   image:
     repository: "thenaim/argocd"
-    tag: "v2.12.0"
+    tag: "v2.13.0"
 ```
 
 ### Sops with an AWS KMS key


### PR DESCRIPTION
Release information: https://github.com/argoproj/argo-cd/releases/tag/v2.13.0